### PR TITLE
[FE] FIX: mocks pie, value 기준시간 수정

### DIFF
--- a/src/mocks/resolvers/pie.ts
+++ b/src/mocks/resolvers/pie.ts
@@ -57,7 +57,7 @@ const checkNull = (value: any) => {
 }
 
 // 기준시간 2023-02-23 00:00:00
-const standardStartTime = 1677078000
+const standardStartTime = 1677078000 * 1000
 
 export const pieResolver: (
   req: RestRequest<PieReq>,

--- a/src/mocks/resolvers/value.ts
+++ b/src/mocks/resolvers/value.ts
@@ -46,7 +46,7 @@ const checkNull = (value: any) => {
 }
 
 // 기준시간 2023-02-23 00:00:00
-const standardStartTime = 1677078000
+const standardStartTime = 1677078000 * 1000
 
 export const valueResolver: (
   req: RestRequest<ValueReq>,
@@ -76,6 +76,5 @@ export const valueResolver: (
     resultValue.value += values[dataInd].value
     startTime += interval
   }
-
   return res(ctx.json(resultValue))
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

> 이슈 https://github.com/42inshin/EXAM_MINI_DASHBOARD/issues/4

unixtime 초 단위 대신 javascript에서 사용하는 밀리초를 기준으로 잡아서 코드 수정을 하는 것이 기존 코드를 최소한으로 건드리는 것으로 보여서 밀리초 단위로 from, to를 넣는 방식을 채택했습니다. 그에 따라서 pie, value 의 기준시간을 밀리초 단위로 변경했습니다.

### 변경 사항

- pie.ts 기준시간을 밀리초 단위로 변경
- value.ts 기준시간을 밀리초 단위로 변경